### PR TITLE
Get the minimum and maximum frequency in one step

### DIFF
--- a/check_line.py
+++ b/check_line.py
@@ -35,8 +35,7 @@ class Spectrum:
         print('Finding expected lines in the spectrum...')
         transition_frequencies = np.loadtxt(list_file, usecols=[1])
         species, transitions = np.loadtxt(list_file, usecols=(0,2),dtype='str', unpack=True)
-        minimum = min(self.frequency)
-        maximum = max(self.frequency)
+        minimum, *_, maximum = sorted(self.frequency)
         potential_lines=[]
         for index, frequency in enumerate(transition_frequencies):
             if minimum <= frequency <= maximum:


### PR DESCRIPTION
This is because:

```
>>> fist, *rest, last = list(range(10))
>>> fist
0
>>> rest
[1, 2, 3, 4, 5, 6, 7, 8]
>>> last
9
```